### PR TITLE
fix: handle WebSocket send errors in broadcastToDashboards

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -505,8 +505,12 @@ function broadcastToDashboards(msg: { type: string; data?: unknown }): void {
   let sent = 0;
   dashboardClients.forEach(client => {
     if (client.ws.readyState === WebSocket.OPEN) {
-      client.ws.send(data);
-      sent++;
+      try {
+        client.ws.send(data);
+        sent++;
+      } catch (err) {
+        console.error(`Failed to send to dashboard client: ${(err as Error).message}`);
+      }
     }
   });
   if (msg.type === 'message') {


### PR DESCRIPTION
## Summary
- Wraps `client.ws.send(data)` in try-catch within `broadcastToDashboards`
- Prevents a single failing/disconnecting client from crashing the broadcast loop for all other dashboard clients
- Logs the error instead of propagating it

## Test plan
- [ ] Connect multiple dashboard clients
- [ ] Disconnect one client mid-broadcast (e.g., kill browser tab during high message volume)
- [ ] Verify remaining clients continue receiving updates without interruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)