### PR TITLE
feat: show agent @-ID next to display name

### DIFF
--- a/server/public/index.html
+++ b/server/public/index.html
@@ -6,8 +6,8 @@
     <title>AgentChat Dashboard</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600&display=swap" rel="stylesheet">
-    <script type="module" crossorigin src="/assets/index-CXB9WyON.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-BFW1EcwM.css">
+    <script type="module" crossorigin src="/assets/index-CoshT9PE.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-BT1C1dnS.css">
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -369,19 +369,11 @@ function Sidebar({ state, dispatch }: { state: DashboardState; dispatch: React.D
     return (a.nick || a.id).localeCompare(b.nick || b.id);
   });
 
-  const nickCounts: Record<string, number> = {};
-  agents.forEach(a => {
-    const nick = a.nick || a.id;
-    nickCounts[nick] = (nickCounts[nick] || 0) + 1;
-  });
-
   const getDisplayName = (agent: Agent): string => {
     const nick = agent.nick || agent.id;
-    if (nickCounts[nick] > 1) {
-      const shortId = agent.id.replace('@', '').slice(0, 6);
-      return `${nick} (${shortId})`;
-    }
-    return nick;
+    const shortId = agent.id.replace('@', '').slice(0, 6);
+    if (nick === agent.id) return nick;
+    return `${nick} (${shortId})`;
   };
 
   const channels = Object.values(state.channels);
@@ -497,6 +489,7 @@ function MessageFeed({ state, send }: { state: DashboardState; send: WsSendFn })
             <span className="from" style={{ color: agentColor(state.agents[msg.from]?.nick || msg.fromNick || msg.from) }}>
               &lt;{state.agents[msg.from]?.nick || msg.fromNick || msg.from}&gt;
             </span>
+            <span className="agent-id">{msg.from}</span>
             {state.agents[msg.from]?.verified && <span className="verified-badge">&#x2713;</span>}
             <span className="content">{msg.content}</span>
           </div>
@@ -538,6 +531,7 @@ function RightPanel({ state, dispatch, send }: { state: DashboardState; dispatch
               <span className="nick" style={{ color: agentColor(entry.nick || entry.id) }}>
                 {entry.nick || entry.id}
               </span>
+              <span className="agent-id">{entry.id}</span>
               <span className="elo">{entry.elo}</span>
             </div>
           ))}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -266,6 +266,12 @@ body {
   margin: 0 4px;
 }
 
+.agent-id {
+  color: var(--text-muted);
+  font-size: 0.8em;
+  margin-left: 2px;
+}
+
 .message .content {
   color: #b0b0b0;
 }


### PR DESCRIPTION
## Summary
- Show the agent's unique @-ID next to the display name in the sidebar, message feed, and leaderboard
- Sidebar: agents with custom nicks now always show `nick (shortid)` instead of only on collision
- Message feed: adds a muted `@agent-id` after the `<nick>` tag on each message
- Leaderboard: adds muted `@agent-id` after each entry's nick
- Styled with muted color and smaller font to avoid visual clutter

Resolves the issue where users can't distinguish agents with the same display name.

## Test plan
- [x] `vite build` succeeds with no errors
- [ ] Visual check: sidebar shows `nick (abc123)` format
- [ ] Visual check: messages show `<nick> @full-id` format
- [ ] Visual check: leaderboard shows agent IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)