### PR TITLE
fix: close agent detail panel on Escape

### DIFF
--- a/server/public/index.html
+++ b/server/public/index.html
@@ -8,8 +8,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
-    <script type="module" crossorigin src="/assets/index-gjEd-fw7.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-ByfeULJp.css">
+    <script type="module" crossorigin src="/assets/index-MLmXZrz1.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-_9gfrZho.css">
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/components/RightPanel.tsx
+++ b/web/src/components/RightPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, FormEvent } from 'react';
+import { useState, useEffect, FormEvent } from 'react';
 import type { DashboardState, DashboardAction, WsSendFn } from '../types';
 import { agentColor, safeUrl, formatTime } from '../utils';
 
@@ -359,6 +359,16 @@ export function RightPanel({ state, dispatch, send, panelWidth }: { state: Dashb
 
   // Agent detail
   const agent = state.selectedAgent;
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && agent) {
+        dispatch({ type: 'SELECT_AGENT', agent: null });
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [agent, dispatch]);
 
   if (!agent) {
     return (

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -217,7 +217,7 @@ export type DashboardAction =
   | { type: 'SKILLS_UPDATE'; data: Skill[] }
   | { type: 'SET_MODE'; mode: string }
   | { type: 'SELECT_CHANNEL'; channel: string }
-  | { type: 'SELECT_AGENT'; agent: Agent }
+  | { type: 'SELECT_AGENT'; agent: Agent | null }
   | { type: 'SET_RIGHT_PANEL'; panel: string }
   | { type: 'TYPING'; data: { from: string; from_name?: string; channel: string } }
   | { type: 'CLEAR_TYPING'; agentId: string }


### PR DESCRIPTION
## Summary
- Press Escape to dismiss the agent detail right panel
- Updates `SELECT_AGENT` action to accept `null` for deselection

## Test plan
- [ ] Click an agent to open the detail panel
- [ ] Press Escape — panel reverts to "Select an agent to view details"
- [ ] Press Escape with no agent selected — no effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)